### PR TITLE
Add 'push' class div to prevent footer bleed when pages are rescaled vertically

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -28,6 +28,7 @@
             <div layout:fragment="content"></div>
         </main>
     </div>
+    <div class="push"></div>
 </div>
 <div th:replace="fragments/footer :: footer"></div>
 <script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>


### PR DESCRIPTION
Addresses bug raised in SFA-1260