### PR TITLE
Reset mobile devices to use one pixel per pixel and added the polyfill

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <common-web-java.version>1.0.1-rc3</common-web-java.version>
     <hamcrest-library-version>2.1</hamcrest-library-version>
     <spring-test.version>5.1.3.RELEASE</spring-test.version>
-    <spring-security-core.version>5.0.7.RELEASE</spring-security-core.version>
+    <spring-security-core.version>5.0.12.RELEASE</spring-security-core.version>
     <web-security-java.version>1.1.0-rc1</web-security-java.version>
 
     <!-- Sonar -->

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -3,6 +3,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
     <link
@@ -15,6 +16,7 @@
 
 </head>
 <body>
+<script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=default%2CNumber.isInteger"></script>
 <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>


### PR DESCRIPTION
Added the polyfill as it was missing and also added the meta tag to force mobile devices use one pixel per pixel for screen resolution so that the css media tags fire correctly.

Updated spring security core.

Resolves: SFA-1725