### PR TITLE
Amended makefile to build for the development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 artifact_name       := company-lookup.web.ch.gov.uk
 commit              := $(shell git rev-parse --short HEAD)
 tag                 := $(shell git tag -l 'v*-rc*' --points-at HEAD)
-version := unversioned
+version 			:= unversioned
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 artifact_name       := company-lookup.web.ch.gov.uk
 commit              := $(shell git rev-parse --short HEAD)
 tag                 := $(shell git tag -l 'v*-rc*' --points-at HEAD)
-version             := $(shell if [[ -n "$(tag)" ]]; then echo $(tag) | sed 's/^v//'; else echo $(commit); fi)
+version := unversioned
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 artifact_name       := company-lookup.web.ch.gov.uk
-commit              := $(shell git rev-parse --short HEAD)
-tag                 := $(shell git tag -l 'v*-rc*' --points-at HEAD)
 version             := unversioned
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 artifact_name       := company-lookup.web.ch.gov.uk
+commit              := $(shell git rev-parse --short HEAD)
+tag                 := $(shell git tag -l 'v*-rc*' --points-at HEAD)
+version             := $(shell if [[ -n "$(tag)" ]]; then echo $(tag) | sed 's/^v//'; else echo $(commit); fi)
 
 .PHONY: all
 all: build
@@ -14,6 +17,9 @@ clean:
 .PHONY: build
 build:
 	mvn compile
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn package -DskipTests=true
+	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: test
 test: test-unit

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 artifact_name       := company-lookup.web.ch.gov.uk
 commit              := $(shell git rev-parse --short HEAD)
 tag                 := $(shell git tag -l 'v*-rc*' --points-at HEAD)
-version 			:= unversioned
+version             := unversioned
 
 .PHONY: all
 all: build


### PR DESCRIPTION
Change the build element of the makefile to allow a copy of the .jar file to be created on the root of the application. This should allow the ubic script to access it.