### PR TITLE
Fix missing main from jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,18 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-maven-plugin.version}</version>
+        <configuration>
+          <mainClass>uk.gov.companieshouse.lookup.Application</mainClass>
+          <layout>ZIP</layout>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
ce28973930fa61f6c9e7923b8552fd4e1ccba6ef introduced pom changes that
 broke the service, causing it to fail to start. The changes should
 have included a main class to be added to the jar by Maven.
Fixed in this commit.
Also fixed missing spring-boot-maven-plugin.version from task.