### PR TITLE
Add no-number link option

### DIFF
--- a/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.lookup.exception.InvalidRequestException;
@@ -23,10 +24,12 @@ import uk.gov.companieshouse.lookup.validation.ValidationError;
 import uk.gov.companieshouse.lookup.validation.ValidationHandler;
 
 @Controller
-@RequestMapping("/company-lookup/search")
+@RequestMapping("/company-lookup")
 public class CompanyLookupController {
 
     private static final String COMPANY_LOOKUP = "lookup/companyLookup";
+    private static final String INVALID_FORWARD_URL = "Invalid forward URL: [%s]";
+    public static final String NO_COMPANY_OPTION = "noCompanyOption";
 
     @Autowired
     private CompanyLookupService companyLookupService;
@@ -34,25 +37,42 @@ public class CompanyLookupController {
     @Autowired
     private ValidationHandler validationHandler;
 
-    @GetMapping
-    public String getCompanyLookup(@Valid ForwardUrl forward, BindingResult forwardResult, Model model) throws InvalidRequestException {
+    @GetMapping("/search")
+    public String getCompanyLookup(@Valid ForwardUrl forward, BindingResult forwardResult, Model model,
+        @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption) throws InvalidRequestException {
         if(forwardResult.hasErrors()) {
-            throw new InvalidRequestException(String.format("Invalid forward URL: [%s]", forward.getForward()));
+            throw new InvalidRequestException(String.format(INVALID_FORWARD_URL, forward.getForward()));
         }
         CompanyLookup companyLookup = new CompanyLookup();
         model.addAttribute("companyLookup", companyLookup);
+        model.addAttribute(NO_COMPANY_OPTION, noCompanyOption);
         return COMPANY_LOOKUP;
     }
+    
+    @GetMapping("/no-number")
+    public String getCompanyLookupNoCompany(@Valid ForwardUrl forward, BindingResult forwardResult,
+        Model model) throws InvalidRequestException {
+        if(forwardResult.hasErrors()) {
+            throw new InvalidRequestException(String.format(INVALID_FORWARD_URL, forward.getForward()));
+        }
+        UriTemplate forwardURI = new UriTemplate(forward.getForward());
+        
+        return UrlBasedViewResolver.REDIRECT_URL_PREFIX + forwardURI.expand("noCompany");
+    }
+    
 
-    @PostMapping
+    @PostMapping("/search")
     public String postCompanyLookup(@Valid ForwardUrl forward, BindingResult forwardResult,
-                                    @ModelAttribute("companyLookup") @Valid CompanyLookup companyLookup,
-                                    BindingResult bindingResult) throws InvalidRequestException, ServiceException {
+        @ModelAttribute("companyLookup") @Valid CompanyLookup companyLookup,
+        BindingResult bindingResult, Model model,
+        @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption)
+        throws InvalidRequestException, ServiceException {
         if(forwardResult.hasErrors()){
-            throw new InvalidRequestException(String.format("Invalid forward URL: [%s]", forward.getForward()));
+            throw new InvalidRequestException(String.format(INVALID_FORWARD_URL, forward.getForward()));
         }
 
         if (bindingResult.hasErrors()) {
+            model.addAttribute(NO_COMPANY_OPTION, noCompanyOption);
             return COMPANY_LOOKUP;
         }
 
@@ -66,6 +86,7 @@ public class CompanyLookupController {
             error.setMessageKey("company.not.found");
             validationErrors.add(error);
             validationHandler.bindValidationErrors(bindingResult, validationErrors);
+            model.addAttribute(NO_COMPANY_OPTION, noCompanyOption);
             return COMPANY_LOOKUP;
         }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,1 +1,3 @@
 company.not.found=You must enter a valid company number
+
+lack.company.number=The company or entity does not have a company number

--- a/src/main/resources/templates/lookup/companyLookup.html
+++ b/src/main/resources/templates/lookup/companyLookup.html
@@ -60,6 +60,12 @@
         </fieldset>
         <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>
 
+        <div th:if="${noCompanyOption}" class="govuk-body">
+              <a class="govuk-link govuk-link--no-visited-state"
+                 th:href="@{/company-lookup/no-number(forward=${#request.getParameter('forward')})}"
+                 th:text="#{lack.company.number}">I don't have a company number</a>
+        </div>
+
       </div>
     </div>
   </form>


### PR DESCRIPTION
Add optional request param `noCompanyOption` required for EFS service.


- show 'no company number' link if `noCompanyOption` is 1 or true-valued
  - e.g. `company-lookup/search?noCompanyOption=1&forward=%2Fefs-submission%2F6086a094ff1f851ee41a5c0e%2Fcompany%2F%7BcompanyNumber%7D%2Fdetails&userEmail=demo%40ch.gov.uk`
- link target is the `forward` URL request param with {companyNumber} placeholder replaced with `noCompany` value
- add unit tests

Resolves:
BI-7388