### PR TITLE
upgrade common-web-java dependency to 1.5.1 to pick up developer link fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <web-security-java.version>1.1.0-rc1</web-security-java.version>
     <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
     <sdk-manager-java.version>1.3.0-rc4</sdk-manager-java.version>
-    <common-web-java.version>1.5.0</common-web-java.version>
+    <common-web-java.version>1.5.1</common-web-java.version>
     <hamcrest-library-version>2.1</hamcrest-library-version>
     <spring-test.version>5.1.3.RELEASE</spring-test.version>
     <web-security-java.version>1.1.0-rc1</web-security-java.version>


### PR DESCRIPTION
fix was made in https://github.com/companieshouse/common-web-java/pull/24, now need to include it in this service