### PR TITLE
Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,11 @@
     <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
     <structured-logging.version>1.5.0-rc2</structured-logging.version>
     <java-session-handler.version>2.2.0</java-session-handler.version>
-    <web-security-java.version>1.1.0-rc1</web-security-java.version>
     <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
     <sdk-manager-java.version>1.3.0-rc4</sdk-manager-java.version>
     <common-web-java.version>1.5.1</common-web-java.version>
     <hamcrest-library-version>2.1</hamcrest-library-version>
     <spring-test.version>5.1.3.RELEASE</spring-test.version>
-    <web-security-java.version>1.1.0-rc1</web-security-java.version>
 
 
     <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
@@ -97,12 +95,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.companieshouse</groupId>
-      <artifactId>web-security-java</artifactId>
-      <version>${web-security-java.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`web-security-java` is defined as a dependency but it is not actually used hence removing it