### PR TITLE
Correct company number label for atribute in h1 wrapper

### DIFF
--- a/src/main/resources/templates/lookup/companyLookup.html
+++ b/src/main/resources/templates/lookup/companyLookup.html
@@ -19,7 +19,7 @@
         th:classappend="${#fields.hasErrors('companyNumber')} ? 'govuk-form-group--error' : ''">
 
         <h1 class="govuk-label-wrapper">
-          <label class="govuk-label govuk-label--l" for="company-lookup-heading">
+          <label class="govuk-label govuk-label--l" for="company-number">
             What is the company number?
           </label>
         </h1>


### PR DESCRIPTION
`What is the company number?` label was previously referencing an ID that doesn't exist in the HTML (simply an error on my part)