### PR TITLE
BI-12160-company-lookup-web-ch-gov-uk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <api-sdk-java.version>4.2.0</api-sdk-java.version>
     <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
     <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
-    <structured-logging.version>1.5.0-rc2</structured-logging.version>
+    <structured-logging.version>1.9.14</structured-logging.version>
     <java-session-handler.version>2.2.0</java-session-handler.version>
     <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
     <sdk-manager-java.version>1.3.0-rc4</sdk-manager-java.version>


### PR DESCRIPTION
### [BI-12160](https://companieshouse.atlassian.net/browse/BI-12160) - Log4j version update for version 2.17.1

#### Fix the log4j2 vulnerability CVE-2021-44228 and [Log4J 2 Vulnerability - Developer advice](https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/3587637603/Log4J+2+Vulnerability+-+Developer+advice)

#### Type of change
##### Update  **structured-logging** from **1.5.0-rc2** to **1.9.14**