### PR TITLE
add missing govuk-templates

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org"
+<html lang="en" class="govuk-template" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
 <head>
     <meta charset="UTF-8"/>
@@ -12,6 +12,10 @@
         rel="icon"
         th:href="@{{cdnUrl}/images/favicon.ico(cdnUrl=${@environment.getProperty('cdn.url')})}"
         type="image/x-icon" />
+    <!--[if !IE 8]><!-->
+        <link th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}" rel="stylesheet" type="text/css" />
+        <link th:href="@{{cdnUrl}/stylesheets/extensions/languages-nav.css(cdnUrl=${@environment.getProperty('cdn.url')})}" rel="stylesheet" type="text/css" />
+    <!--<![endif]-->
 </head>
 <body>
 <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=default%2CNumber.isInteger"></script>
@@ -29,6 +33,7 @@
         <div th:replace="fragments/betaBanner :: betaBanner (surveyLink = 'https://www.smartsurvey.co.uk/s/acctsfiling')"></div>
         </section>
         <div th:replace="fragments/backButtonLink :: backButtonLink"></div>
+        <div th:replace="locales/localesBanner2 :: localesBanner"></div>
         <main id="content" role="main" class="govuk-main-wrapper">
             <div layout:fragment="content"></div>
         </main>


### PR DESCRIPTION
this sorts the menu,
there is to fix the separator which is put as last
![Screenshot 2023-09-26 at 08 11 01](https://github.com/companieshouse/company-lookup.web.ch.gov.uk/assets/12054005/8ac798c7-30d9-4e17-b97b-dbcf49a20209)
