### PR TITLE
Use CH session to store locales

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <java-session-handler.version>2.2.0</java-session-handler.version>
     <spring-security-core.version>5.1.11.RELEASE</spring-security-core.version>
     <sdk-manager-java.version>1.3.0-rc4</sdk-manager-java.version>
-    <common-web-java.version>1.5.1</common-web-java.version>
+    <common-web-java.version>1.5.3</common-web-java.version>
     <hamcrest-library-version>2.1</hamcrest-library-version>
     <spring-test.version>5.1.3.RELEASE</spring-test.version>
 

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.lookup.internationalisation;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.LocaleResolver;
+import uk.gov.companieshouse.session.Session;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+public class ChSessionLocaleResolver implements LocaleResolver {
+    public static final String EXTRA_DATA_SESSION_KEY = "extra_data";
+    public static final String LANG_SESSION_KEY = "lang";
+    private SessionProvider sessionProvider;
+    private Locale defaultLocale = Locale.getDefault();
+
+    @Autowired
+    public ChSessionLocaleResolver(SessionProvider sessionProvider) {
+        this.sessionProvider = sessionProvider;
+    }
+
+    public ChSessionLocaleResolver() {}
+
+    @Override
+    public Locale resolveLocale(HttpServletRequest httpServletRequest) {
+        return getLocaleFromSession();
+    }
+
+    @Override
+    public void setLocale(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Locale locale) {
+        setLocaleInSession(locale);
+    }
+
+    private Locale getLocaleFromSession() {
+        Map<String, Object> sessionData = sessionProvider.getSessionDataFromContext();
+        Object extraDataObj = sessionData.get(EXTRA_DATA_SESSION_KEY);
+
+        if (extraDataObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> extraData = (Map<String, String>) extraDataObj;
+            String languageTag = extraData.get(LANG_SESSION_KEY);
+            if (StringUtils.isEmpty(languageTag)) {
+                return defaultLocale;
+            }
+
+            return Locale.forLanguageTag(languageTag);
+        }
+
+        return Locale.getDefault();
+    }
+
+    private void setLocaleInSession(Locale locale) {
+        Session session = sessionProvider.getSessionFromContext();
+        Map<String, Object> sessionData = session.getData();
+        Object extraDataObj = sessionData.get(EXTRA_DATA_SESSION_KEY);
+
+        if (extraDataObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> extraData = (Map<String, String>) extraDataObj;
+            extraData.put(LANG_SESSION_KEY, locale.toLanguageTag());
+            session.store();
+        }
+    }
+
+    public void setSessionProvider(SessionProvider sessionProvider) {
+        this.sessionProvider = sessionProvider;
+    }
+
+    public void setDefaultLocale(Locale defaultLocale) {
+        this.defaultLocale = defaultLocale;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
@@ -13,8 +13,8 @@ import java.util.Map;
 
 @Component
 public class ChSessionLocaleResolver implements LocaleResolver {
-    public static final String EXTRA_DATA_SESSION_KEY = "extra_data";
-    public static final String LANG_SESSION_KEY = "lang";
+    private static final String EXTRA_DATA_SESSION_KEY = "extra_data";
+    private static final String LANG_SESSION_KEY = "lang";
     private SessionProvider sessionProvider;
     private Locale defaultLocale = Locale.getDefault();
 

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolver.java
@@ -27,7 +27,13 @@ public class ChSessionLocaleResolver implements LocaleResolver {
 
     @Override
     public Locale resolveLocale(HttpServletRequest httpServletRequest) {
-        return getLocaleFromSession();
+        Locale locale = getLocaleFromSession();
+        httpServletRequest.setAttribute("langInSession", locale != null);
+        if (locale == null) {
+            locale = defaultLocale;
+        }
+
+        return locale;
     }
 
     @Override
@@ -44,13 +50,13 @@ public class ChSessionLocaleResolver implements LocaleResolver {
             Map<String, String> extraData = (Map<String, String>) extraDataObj;
             String languageTag = extraData.get(LANG_SESSION_KEY);
             if (StringUtils.isEmpty(languageTag)) {
-                return defaultLocale;
+                return null;
             }
 
             return Locale.forLanguageTag(languageTag);
         }
 
-        return Locale.getDefault();
+        return null;
     }
 
     private void setLocaleInSession(Locale locale) {

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/InternationalisationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/InternationalisationConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.lookup.internationalisation;
 
 import java.util.Locale;
+import java.util.Map;
 
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -11,34 +12,29 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
-import org.springframework.web.servlet.i18n.SessionLocaleResolver;
 
 @Configuration
 @EnableWebMvc
-public class InternationalisationConfig implements WebMvcConfigurer{
-    
+public class InternationalisationConfig implements WebMvcConfigurer {
+
     @Bean
     public MessageSource messageSource(){
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
-        messageSource.setBasename("messages");
+        messageSource.setBasenames("messages", "locales/messages", "locales/common-messages");
         messageSource.setDefaultEncoding("UTF-8");
         return messageSource;
     }
 
     @Bean
-    public LocaleResolver localeResolver(){
-        SessionLocaleResolver resolver = new SessionLocaleResolver();
-
-        // Set a default locale to be used
-        resolver.setDefaultLocale(Locale.ENGLISH);
-        return resolver;
+    public LocaleResolver localeResolver(ChSessionLocaleResolver chSessionLocaleResolver) {
+        chSessionLocaleResolver.setDefaultLocale(Locale.ENGLISH);
+        return chSessionLocaleResolver;
     }
 
     @Bean
     public LocaleChangeInterceptor localeChangeInterceptor() {
         LocaleChangeInterceptor interceptor = new LocaleChangeInterceptor();
 
-        // setting the lang param to switch languages on request
         interceptor.setParamName("lang");
         return interceptor;
     }

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/InternationalisationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/InternationalisationConfig.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.lookup.internationalisation;
 
 import java.util.Locale;
-import java.util.Map;
 
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/SessionProvider.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/SessionProvider.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.lookup.internationalisation;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.session.Session;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+
+import java.util.Map;
+
+// Having an instance of this class allows to it to be mocked
+@Component
+public class SessionProvider {
+    public Map<String, Object> getSessionDataFromContext() {
+        return SessionHandler.getSessionDataFromContext();
+    }
+
+    public Session getSessionFromContext() {
+        return SessionHandler.getSessionFromContext();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/lookup/internationalisation/SessionProvider.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/internationalisation/SessionProvider.java
@@ -6,7 +6,6 @@ import uk.gov.companieshouse.session.handler.SessionHandler;
 
 import java.util.Map;
 
-// Having an instance of this class allows to it to be mocked
 @Component
 public class SessionProvider {
     public Map<String, Object> getSessionDataFromContext() {

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -34,7 +34,9 @@
         <div th:replace="fragments/betaBanner :: betaBanner (surveyLink = 'https://www.smartsurvey.co.uk/s/acctsfiling')"></div>
         </section>
         <div th:replace="fragments/backButtonLink :: backButtonLink"></div>
-        <div th:replace="fragments/localesBanner :: localesBanner"></div>
+        <div th:if="${#httpServletRequest.getAttribute('langInSession')}">
+            <div th:replace="fragments/localesBanner :: localesBanner"></div>
+        </div>
         <main id="content" role="main" class="govuk-main-wrapper">
             <div layout:fragment="content"></div>
         </main>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title layout:title-pattern="$CONTENT_TITLE"></title>
     <link
+            th:href="@{{cdnUrl}/stylesheets/extensions/languages-nav.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+            rel="stylesheet" type="text/css">
+    <link
         th:href="@{{cdnUrl}/stylesheets/chs-styles.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
         media="all" rel="stylesheet" type="text/css" />
     <link
@@ -31,6 +34,7 @@
         <div th:replace="fragments/betaBanner :: betaBanner (surveyLink = 'https://www.smartsurvey.co.uk/s/acctsfiling')"></div>
         </section>
         <div th:replace="fragments/backButtonLink :: backButtonLink"></div>
+        <div th:replace="fragments/localesBanner :: localesBanner"></div>
         <main id="content" role="main" class="govuk-main-wrapper">
             <div layout:fragment="content"></div>
         </main>

--- a/src/test/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolverTest.java
+++ b/src/test/java/uk/gov/companieshouse/lookup/internationalisation/ChSessionLocaleResolverTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.lookup.internationalisation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import uk.gov.companieshouse.session.Session;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChSessionLocaleResolverTest {
+
+    @Mock
+    private HttpServletResponse mockResponse;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private SessionProvider sessionProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    private Map<String, Object> sessionData;
+    private Map<String, Object> extraData;
+
+    @InjectMocks
+    private ChSessionLocaleResolver localeResolver;
+
+
+    @BeforeEach
+    public void setUp() {
+        localeResolver.setSessionProvider(sessionProvider);
+        ReflectionTestUtils.setField(localeResolver, "defaultLocale", Locale.ENGLISH);
+    }
+
+    private void initSessionDataMaps(String lang) {
+        sessionData = new HashMap<>();
+        extraData = new HashMap<>();
+        sessionData.put("extra_data", extraData);
+        if (lang != null) {
+            extraData.put("lang", lang);
+        }
+    }
+
+    private void setupSessionData(String lang) {
+        initSessionDataMaps(lang);
+        when(sessionProvider.getSessionDataFromContext()).thenReturn(sessionData);
+    }
+
+    @Test
+    @DisplayName("Resolves to the default locale if no locale is in the session")
+    void testResolveDefaultLocale() {
+        setupSessionData(null);
+        Locale locale = localeResolver.resolveLocale(request);
+
+        assertEquals(Locale.ENGLISH, locale);
+    }
+
+    @Test
+    @DisplayName("Resolves to the locale in the session when present")
+    void testResolveLocale() {
+        setupSessionData("cy");
+        Locale locale = localeResolver.resolveLocale(request);
+
+        Locale welshLocale = new Locale("cy");
+        assertEquals(welshLocale, locale);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/lookup/internationalisationConfig/InternationalisationConfigTests.java
+++ b/src/test/java/uk/gov/companieshouse/lookup/internationalisationConfig/InternationalisationConfigTests.java
@@ -1,24 +1,44 @@
 package uk.gov.companieshouse.lookup.internationalisationConfig;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Locale;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
-import org.springframework.web.servlet.i18n.SessionLocaleResolver;
-
+import uk.gov.companieshouse.lookup.internationalisation.ChSessionLocaleResolver;
 import uk.gov.companieshouse.lookup.internationalisation.InternationalisationConfig;
+import uk.gov.companieshouse.lookup.internationalisation.SessionProvider;
+import uk.gov.companieshouse.session.Session;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class InternationalisationConfigTests {
 
-    private final InternationalisationConfig config = new InternationalisationConfig();
+    @InjectMocks
+    private InternationalisationConfig config;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private SessionProvider sessionProvider;
 
     @Test
     @DisplayName("Test MessageSource bean configuration")
@@ -43,13 +63,20 @@ class InternationalisationConfigTests {
     @Test
     @DisplayName("Test LocaleResolver bean configuration")
     void testLocaleResolver() throws IllegalArgumentException, SecurityException {
-        LocaleResolver localeResolver = config.localeResolver();
+        ChSessionLocaleResolver chSessionLocaleResolver = spy(ChSessionLocaleResolver.class);
+        chSessionLocaleResolver.setDefaultLocale(Locale.ENGLISH);
+        LocaleResolver localeResolver = config.localeResolver(new ChSessionLocaleResolver(sessionProvider));
         
-        assertThat(localeResolver).isInstanceOf(SessionLocaleResolver.class);
+        assertThat(localeResolver).isInstanceOf(ChSessionLocaleResolver.class);
 
-        MockHttpServletRequest request = new MockHttpServletRequest();
+        Map<String, Object> sessionData = new HashMap<>();
+        Map<String, String> extraData = new HashMap<>();
+        sessionData.put("extra_data", extraData);
+        when(sessionProvider.getSessionDataFromContext()).thenReturn(sessionData);
+        ((ChSessionLocaleResolver)localeResolver).setSessionProvider(sessionProvider);
 
-        Locale resolvedLocale = localeResolver.resolveLocale(request);
+        MockHttpServletRequest httpServletRequest = new MockHttpServletRequest();
+        Locale resolvedLocale = localeResolver.resolveLocale(httpServletRequest);
 
         assertThat(resolvedLocale).isEqualTo(Locale.ENGLISH);
     }


### PR DESCRIPTION
Change the LocaleResolver to use the Companies House session to resolve the locale.
This allows the locale to be passed easily over service boundaries. 
Also, adds the locale banner to change locale only when the locale is in session meaning it only shows for services that handle different locales.

- Add ChSessionLocaleResolver
- Update base layout to have locale banner

Resolves: [AOAF-523](https://companieshouse.atlassian.net/browse/AOAF-523)

[AOAF-523]: https://companieshouse.atlassian.net/browse/AOAF-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ