### PR TITLE
feat: add back link to company-lookup

### DIFF
--- a/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
@@ -35,6 +35,8 @@ import uk.gov.companieshouse.lookup.helper.PageTitleHelper;
 public class CompanyLookupController {
 
     public static final String NO_COMPANY_OPTION = "noCompanyOption";
+    public static final String BACK_LINK_KEY = "backLink";
+    private static final String JS_HISTORY_BACK = "javascript:window.history.back()";
     private static final String COMPANY_LOOKUP = "lookup/companyLookup";
     public static final String TITLE = "title";
     private static final String INVALID_FORWARD_URL = "Invalid forward URL: [%s]";
@@ -86,6 +88,7 @@ public class CompanyLookupController {
         PageTitleHelper titleHelper = new  PageTitleHelper();
         String title = titleHelper.getPageTitleFromForwardURL(forward);
         model.addAttribute(TITLE, title);
+        model.addAttribute(BACK_LINK_KEY, JS_HISTORY_BACK);
 
         return COMPANY_LOOKUP;
     }

--- a/src/test/java/uk/gov/companieshouse/lookup/controller/CompanyLookupControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/lookup/controller/CompanyLookupControllerTest.java
@@ -95,7 +95,8 @@ class CompanyLookupControllerTest {
                 .andExpect(view().name(TEMPLATE))
                 .andExpect(model().attributeExists(MODEL_ATTRIBUTE))
                 .andExpect(model().attributeExists(TITLE_ATTRIBUTE))
-                .andExpect(model().attribute(TITLE_ATTRIBUTE, DEFAULT_TITLE_PROPERTY));
+                .andExpect(model().attribute(TITLE_ATTRIBUTE, DEFAULT_TITLE_PROPERTY))
+                .andExpect(model().attribute("backLink", "javascript:window.history.back()"));
     }
 
     @Test


### PR DESCRIPTION
This pull request adds a back link to the company lookup page to enhance navigation and updates the corresponding test to verify this behavior.

Enhancement to navigation:

* Added a new model attribute `backLink` with the value `javascript:window.history.back()` in the `getCompanyLookup` method of `CompanyLookupController`, allowing the view to provide a "back" navigation option. [[1]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R38-R39) [[2]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R91)

Test updates:

* Updated the `getCompanyLookup` test in `CompanyLookupControllerTest` to assert that the `backLink` attribute is present and has the correct value.

[fs-248](https://companieshouse.atlassian.net/browse/FS-248)