### PR TITLE
feat: add back link support

### DIFF
--- a/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.lookup.Application;
 import uk.gov.companieshouse.lookup.exception.InvalidRequestException;
 import uk.gov.companieshouse.lookup.exception.ServiceException;
+import uk.gov.companieshouse.lookup.helper.LinkUtils;
 import uk.gov.companieshouse.lookup.model.Company;
 import uk.gov.companieshouse.lookup.model.CompanyLookup;
 import uk.gov.companieshouse.lookup.model.ForwardUrl;
@@ -35,6 +36,8 @@ import uk.gov.companieshouse.lookup.helper.PageTitleHelper;
 public class CompanyLookupController {
 
     public static final String NO_COMPANY_OPTION = "noCompanyOption";
+    public static final String BACK_LINK_KEY = "backLink";
+    public static final String BACK_LINK_PARAM = "backLink";
     private static final String COMPANY_LOOKUP = "lookup/companyLookup";
     public static final String TITLE = "title";
     private static final String INVALID_FORWARD_URL = "Invalid forward URL: [%s]";
@@ -45,11 +48,15 @@ public class CompanyLookupController {
 
     private final ValidationHandler validationHandler;
 
+    private final LinkUtils linkUtils;
+
     @Autowired
     public CompanyLookupController(CompanyLookupService companyLookupService,
-            ValidationHandler validationHandler) {
+            ValidationHandler validationHandler,
+            LinkUtils linkUtils) {
         this.companyLookupService = companyLookupService;
         this.validationHandler = validationHandler;
+        this.linkUtils = linkUtils;
     }
 
     /**
@@ -67,7 +74,8 @@ public class CompanyLookupController {
             BindingResult forwardResult,
             HttpServletRequest httpServletRequest,
             Model model,
-            @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption)
+            @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption,
+            @RequestParam(name = BACK_LINK_PARAM, required = false) String backLink)
             throws InvalidRequestException {
         if (forwardResult.hasErrors()) {
             LOGGER.errorRequest(httpServletRequest, String.format(INVALID_FORWARD_URL, forward.getForward()));
@@ -86,6 +94,8 @@ public class CompanyLookupController {
         PageTitleHelper titleHelper = new  PageTitleHelper();
         String title = titleHelper.getPageTitleFromForwardURL(forward);
         model.addAttribute(TITLE, title);
+        linkUtils.resolveRelativeLink(backLink).ifPresent(validRelativeLink -> model.addAttribute(BACK_LINK_KEY,
+                validRelativeLink));
 
         return COMPANY_LOOKUP;
     }

--- a/src/main/java/uk/gov/companieshouse/lookup/helper/LinkUtils.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/helper/LinkUtils.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.lookup.helper;
+
+import java.net.URI;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LinkUtils {
+
+    public Optional<String> resolveRelativeLink(String link) {
+        if (isSafeRelativeLink(link)) {
+            return Optional.of(link);
+        }
+
+        return Optional.empty();
+    }
+
+    public boolean isSafeRelativeLink(String link) {
+        if (link == null || link.isBlank()) {
+            return false;
+        }
+
+        try {
+            URI uri = URI.create(link);
+            return uri.getScheme() == null
+                    && uri.getHost() == null
+                    && link.startsWith("/")
+                    && !link.startsWith("//");
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+}
+
+

--- a/src/test/java/uk/gov/companieshouse/lookup/controller/CompanyLookupControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/lookup/controller/CompanyLookupControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.lookup.controller;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,6 +32,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.lookup.config.MessageConfig;
+import uk.gov.companieshouse.lookup.helper.LinkUtils;
 import uk.gov.companieshouse.lookup.internationalisation.ChSessionLocaleResolver;
 import uk.gov.companieshouse.lookup.model.Company;
 import uk.gov.companieshouse.lookup.service.CompanyLookupService;
@@ -53,6 +55,7 @@ class CompanyLookupControllerTest {
     private static final String FORWARD_URL_CS01 = "/confirmation-statement/";
     private static final String DEFAULT_TITLE_PROPERTY = "company.number.title";
     private static final String CS01_TITLE_PROPERTY = "title.formtype.confirmation-statement";
+    private static final String VALID_BACK_LINK = "/confirmation-statement/";
 
     @Autowired
     private WebApplicationContext webApplicationContext;
@@ -75,6 +78,9 @@ class CompanyLookupControllerTest {
     @MockitoBean
     private ChSessionLocaleResolver chSessionLocaleResolver;
 
+    @MockitoBean
+    private LinkUtils linkUtils;
+
     @BeforeAll
     public static void setUp() {
         System.setProperty("COOKIE_NAME", "__SID");
@@ -83,6 +89,7 @@ class CompanyLookupControllerTest {
     @BeforeEach
     public void setUpBeforeEach() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        when(linkUtils.resolveRelativeLink(any())).thenReturn(Optional.empty());
     }
 
     @Test
@@ -94,8 +101,37 @@ class CompanyLookupControllerTest {
                 .andDo(print()).andExpect(status().isOk())
                 .andExpect(view().name(TEMPLATE))
                 .andExpect(model().attributeExists(MODEL_ATTRIBUTE))
-                .andExpect(model().attributeExists(TITLE_ATTRIBUTE))
-                .andExpect(model().attribute(TITLE_ATTRIBUTE, DEFAULT_TITLE_PROPERTY));
+                .andExpect(model().attribute(TITLE_ATTRIBUTE, DEFAULT_TITLE_PROPERTY))
+                .andExpect(model().attributeDoesNotExist("backLink"));
+    }
+
+    @Test
+    @DisplayName("Get Company Lookup - when valid back link is provided then model includes backLink value")
+    void getCompanyLookupWhenValidBackLinkProvidedThenModelIncludesBackLinkValue() throws Exception {
+        when(chSessionLocaleResolver.resolveLocale(any())).thenReturn(Locale.ENGLISH);
+        when(linkUtils.resolveRelativeLink(VALID_BACK_LINK)).thenReturn(Optional.of(VALID_BACK_LINK));
+
+        this.mockMvc.perform(get(COMPANY_LOOKUP_URL, FORWARD_URL_PARAM)
+                        .param("backLink", VALID_BACK_LINK))
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(view().name(TEMPLATE))
+                .andExpect(model().attribute("backLink", VALID_BACK_LINK));
+    }
+
+    @Test
+    @DisplayName("Get Company Lookup - when invalid back link is provided then model excludes backLink")
+    void getCompanyLookupWhenInvalidBackLinkProvidedThenModelExcludesBackLink() throws Exception {
+        when(chSessionLocaleResolver.resolveLocale(any())).thenReturn(Locale.ENGLISH);
+
+        String invalidBackLink = "https://example.com";
+
+        when(linkUtils.resolveRelativeLink(invalidBackLink)).thenReturn(Optional.empty());
+
+        this.mockMvc.perform(get(COMPANY_LOOKUP_URL, FORWARD_URL_PARAM)
+                        .param("backLink", invalidBackLink))
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(view().name(TEMPLATE))
+                .andExpect(model().attributeDoesNotExist("backLink"));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/lookup/helper/LinkUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/lookup/helper/LinkUtilsTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.lookup.helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class LinkUtilsTest {
+
+    private final LinkUtils linkUtils = new LinkUtils();
+
+    @DisplayName("Accepts safe relative links")
+    @ParameterizedTest(name = "{index} => {0}: {1}")
+    @CsvSource(delimiter = '|', textBlock = """
+            root path   | /confirmation-statement/
+            nested path | /confirmation-statement/confirm
+            root only   | /
+            """)
+    void isSafeRelativeLinkReturnsTrueForValidPaths(String testCase, String path) {
+        assertTrue(linkUtils.isSafeRelativeLink(path));
+        assertTrue(linkUtils.resolveRelativeLink(path).isPresent());
+    }
+
+    @DisplayName("Rejects unsafe relative links")
+    @ParameterizedTest(name = "{index} => {0}: {1}")
+    @CsvSource(delimiter = '|', nullValues = "NULL", textBlock = """
+            null link           | NULL
+            blank link          |
+            absolute url        | https://example.com/confirmation-statement
+            scheme relative url | //example.com/confirmation-statement
+            no leading slash    | confirmation-statement/confirm
+            """)
+    void isSafeRelativeLinkReturnsFalseForInvalidPaths(String testCase, String path) {
+        assertFalse(linkUtils.isSafeRelativeLink(path));
+        assertTrue(linkUtils.resolveRelativeLink(path).isEmpty());
+    }
+
+    @Test
+    void resolveRelativeLinkReturnsExpectedOptionalValue() {
+        String validPath = "/confirmation-statement/confirm";
+        assertTrue(linkUtils.resolveRelativeLink(validPath).isPresent());
+        assertEquals(validPath, linkUtils.resolveRelativeLink(validPath).get());
+        assertTrue(linkUtils.resolveRelativeLink("https://example.com").isEmpty());
+    }
+}


### PR DESCRIPTION
This pull request introduces safe handling of back links in the company lookup flow by adding a new utility for validating relative links and updating both controller logic and tests to incorporate this. The main focus is to ensure that only safe, relative URLs are accepted for back links, preventing open redirect vulnerabilities.

**Back link handling and validation:**

* Added `LinkUtils` utility (`src/main/java/uk/gov/companieshouse/lookup/helper/LinkUtils.java`) to validate and resolve safe relative links, ensuring only links starting with a single `/` and without a scheme or host are accepted.
* Updated `CompanyLookupController` to accept an optional `backLink` parameter, validate it using `LinkUtils`, and, if valid, add it to the model for use in views. Constants for back link handling were also introduced. [[1]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R24) [[2]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R39-R40) [[3]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R51-R59) [[4]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867L70-R78) [[5]](diffhunk://#diff-80109631be33753856945b55a9007e7fe8d1e9632adb69b4ab9946c08b04b867R97-R98)

**Testing and coverage:**

* Added comprehensive unit tests for `LinkUtils` to verify correct acceptance and rejection of various link formats.
* Updated `CompanyLookupControllerTest` to mock `LinkUtils`, verify correct model attributes for valid and invalid back links, and ensure coverage of the new logic. [[1]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdR4) [[2]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdR35) [[3]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdR58) [[4]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdR81-R83) [[5]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdR92) [[6]](diffhunk://#diff-7344f685c17b3638e43ac870aee25a24143ff053c4ce22177a32d0c8d1af17cdL97-R130)

These changes collectively strengthen the security and reliability of back link handling in the company lookup feature.

[fs-243](https://companieshouse.atlassian.net/browse/FS-248)