### PR TITLE
IDVA6-2743 preserving backlink on post request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
+++ b/src/main/java/uk/gov/companieshouse/lookup/controller/CompanyLookupController.java
@@ -140,12 +140,15 @@ public class CompanyLookupController {
     public String postCompanyLookup(@Valid ForwardUrl forward, BindingResult forwardResult,
             @ModelAttribute("companyLookup") @Valid CompanyLookup companyLookup,
             BindingResult bindingResult, Model model,
-            @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption)
+            @RequestParam(name = NO_COMPANY_OPTION, required = false) String noCompanyOption,
+            @RequestParam(name = BACK_LINK_PARAM, required = false) String backLink)
             throws InvalidRequestException, ServiceException {
 
         PageTitleHelper titleHelper = new  PageTitleHelper();
         String title = titleHelper.getPageTitleFromForwardURL(forward);
         model.addAttribute(TITLE, title);
+        linkUtils.resolveRelativeLink(backLink).ifPresent(validRelativeLink -> model.addAttribute(BACK_LINK_KEY,
+                validRelativeLink));
         if (forwardResult.hasErrors()) {
             throw new InvalidRequestException(
                     String.format(INVALID_FORWARD_URL, forward.getForward()));


### PR DESCRIPTION
Adding a backUrl query parameter to the company lookup common component to allow consuming services to provide a back link so users can navigate back to the calling service.